### PR TITLE
Change name of `__fake_gem` to `fake_gem__` for rubygems 3.x compatibility

### DIFF
--- a/fake_gem__.gemspec
+++ b/fake_gem__.gemspec
@@ -1,5 +1,5 @@
 Gem::Specification.new do |s|
-  s.name = '__fake_gem'
+  s.name = 'fake_gem__'
   s.version = '0.0.0'
   s.authors = ['Paul Morgan']
   s.summary = 'pre-commit hooks for ruby projects'


### PR DESCRIPTION
The name `__fake_gem` is incompatible with `rubygems >= 3`. This changes the name to `fake_gem__`. I'm open to other ideas for naming but figured this had just as little chance of a name collision as the previous name which seemed like the original intent.

Symptom:
```
An unexpected error has occurred: CalledProcessError: Command: ('/usr/local/bin/ruby', u'/usr/local/bin/gem', 'build', '__fake_gem.gemspec')

Errors: 
    WARNING:  See http://guides.rubygems.org/specification-reference/ for help
    ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
        invalid value for attribute name: "__fake_gem" can not begin with a period, dash, or underscore
```

Reference:
https://github.com/rubygems/rubygems/pull/2432#issuecomment-449863151

-----

My apologies in advance that this may not conform to CONTRIBUTING guidelines yet but can make any necessary changes.