### PR TITLE
shfmt: add user-friendly hints if hook fails

### DIFF
--- a/pre_commit_hooks/shfmt
+++ b/pre_commit_hooks/shfmt
@@ -15,12 +15,20 @@ if ! command -v shfmt >/dev/null 2>&1; then
   exit 1
 fi
 
-output="$(shfmt "$@" 2>&1)"
+readonly cmd="shfmt $*"
+echo "[RUN] ${cmd}"
+output="$(${cmd} 2>&1)"
 readonly output
 
 if [ -n "${output}" ]; then
+  echo '[FAIL]'
+  echo
   echo "${output}"
   echo
   echo 'The above files have style errors.'
+  echo 'Use "shfmt -d" option to show diff.'
+  echo 'Use "shfmt -w" option to write (autocorrect).'
   exit 1
+else
+  echo '[PASS]'
 fi


### PR DESCRIPTION
This commit has no effect if the hook passes.
Example:

    shfmt (local).................................................................Passed

However show on failure:

* The actual command that was executed, with CLI options and filelist
* Hints to use `-d` or `-w` CLI options.

Example if `ci/test` has errors:

    shfmt (local).................................................................Failed
    hookid: shfmt

    [RUN] shfmt -l -i 2 -ci ci/bootstrap ci/test pre_commit_hooks/check-mailmap pre_commit_hooks/forbid-binary pre_commit_hooks/forbid-space-in-indent pre_commit_hooks/git-check pre_commit_hooks/git-dirty pre_commit_hooks/script_must_have_extension pre_commit_hooks/script_must_not_have_extension pre_commit_hooks/shellcheck pre_commit_hooks/shfmt
    [FAIL]

    ci/test

    The above files have style errors.
    Use "shfmt -d" option to show diff.
    Use "shfmt -w" option to write (autocorrect).