### PR TITLE
Fix .pre-commit-config.yaml sample in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Git hooks to integrate with [pre-commit](http://pre-commit.com).
 Add to `.pre-commit-config.yaml` in your git repo:
 
     - repo: https://github.com/jumanjihouse/pre-commit-hooks
-      sha: 1.11.0
+      rev: 1.11.0
       hooks:
         - id: bundler-audit
         - id: check-mailmap


### PR DESCRIPTION
Updates the readme to use "rev" instead of "sha". Sounds like this was renamed in [pre-commit 1.7](https://pre-commit.com/#pre-commit-configyaml---repos). Without this change, running precommit with the sample produces.

```
$ pre-commit run markdownlint --all-files
[WARNING] Unexpected key(s) present on https://github.com/jumanjihouse/pre-commit-hooks: sha
```