### PR TITLE
avoid /usr/bin/env in the shebang

### DIFF
--- a/pre_commit_hooks/require-ascii.py
+++ b/pre_commit_hooks/require-ascii.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!python
 
 """
 require-ascii


### PR DESCRIPTION
For people who use red hat software collections,
`/usr/bin/env python` breaks.