### PR TITLE
shfmt: don't override project defaults

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -109,5 +109,5 @@
   language: script
   entry: pre_commit_hooks/shfmt
   types: [shell]
-  args: ['-l', '-i', '2', '-ci']
+  args: ['-l', '-ci']
   additional_dependencies: [shfmt]


### PR DESCRIPTION
shfmt honors .editorconfig files in the project but the command-line arguments override this. Relying on editorconfig files means that projects only have to configure this value in one place for all of their tools rather than each tool.