### PR TITLE
really do not override editorconfig

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -109,5 +109,5 @@
   language: script
   entry: pre_commit_hooks/shfmt
   types: [shell]
-  args: ['-l', '-ci']
+  args: ['-l']
   additional_dependencies: [shfmt]

--- a/README.md
+++ b/README.md
@@ -421,8 +421,7 @@ Run `shfmt` against scripts with args.
 This hook uses the `identify` library of pre-commit to identify shell scripts.
 If the file is a shell script, then run shfmt against the file.
 
-By default, this hooks passes `-l -ci` to shfmt to conform to the
-[Google Shell Style Guide](https://google.github.io/styleguide/shell.xml).
+By default, this hooks passes only `-l` to `shfmt`.
 Override locally with the `args` parameter in `.pre-commit-config.yaml`.
 
 :bulb: Recent versions of `shfmt` automatically use the indentation


### PR DESCRIPTION
Commit f4c17778e3dfb767a34c051eb9f0725a47078ace initiated this,
but it turns out that we need to remove `-ci`, too.