### PR TITLE
make require-ascii hook informative on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
   build:
     docker:
       # https://github.com/jumanjihouse/cci/pulls?q=is%3Apr+is%3Aclosed
-      - image: jumanjiman/cci:20200323.2227
+      - image: jumanjiman/cci:20200424.1156
 
     working_directory: ~/workdir/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,7 +53,6 @@ repos:
         entry: pre_commit_hooks/require-ascii.py
         language: python
         types: [text]
-        additional_dependencies: [chardet]
         exclude: ^ci/ansi$  # 3rd-party script
 
       - id: shellcheck

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -72,7 +72,6 @@
   entry: require-ascii.py
   language: python
   types: [text]
-  additional_dependencies: [chardet]
 
 - id: rubocop
   name: Check Ruby style with rubocop and rubocop-rspec

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Git hooks to integrate with [pre-commit](http://pre-commit.com).
 Add to `.pre-commit-config.yaml` in your git repo:
 
     - repo: https://github.com/jumanjihouse/pre-commit-hooks
-      rev: 2.0.0
+      rev: master  # or specific git tag
       hooks:
         - id: bundler-audit
         - id: check-mailmap

--- a/pre_commit_hooks/require-ascii.py
+++ b/pre_commit_hooks/require-ascii.py
@@ -8,25 +8,26 @@ require-ascii
 from __future__ import print_function
 
 import sys
-import chardet
 
 status = 0
 
 for filename in sys.argv:
-    fh = open(filename, 'rb')
-    data = fh.read()
-    dict = chardet.detect(data)
-    fh.close
+    line_num = 0
+    with open(filename, 'r', encoding='UTF-8') as fh:
+        while True:
+            line_num += 1
+            line = fh.readline()
+            if not line:
+                break
 
-    if dict['encoding'] in (None, 'ascii'):
-        result = '[OK]'
-    else:
-        result = '[ERROR]'
-        status = 1
+            col_num = 0
+            for char in line:
+                col_num += 1
+                if ord(char) > 127:
+                    print(
+                        f"{filename}: line {line_num} column {col_num} " +
+                        f"character \"{char}\" (decimal {ord(char)})"
+                        )
+                    status = 1
 
-    # With `--verbose', pre-commit shows output regardless of exit status.
-    # Without `--verbose', pre-commit only shows output when status != 0.
-    print(result.ljust(8) + filename.ljust(50), end='')
-    print(dict)
-
-exit(status)
+sys.exit(status)

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,6 @@ setup(
         'pre_commit_hooks',
     ],
 
-    install_requires=[
-        'chardet',
-    ],
-
     scripts=[
         'pre_commit_hooks/require-ascii.py',
     ],


### PR DESCRIPTION
If a file has non-ascii characters,
inform the user about the offending character.
For example:
    
    ci/ansi: line 5 column 3 character "©" (decimal 169)
