### PR TITLE
fix shellcheck hook for pre-commit 2.10

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -95,7 +95,6 @@
   language: script
   types: [shell]
   args: [-e, SC1091]
-  additional_dependencies: [shellcheck]
 
 - id: script-must-have-extension
   name: Non-executable shell script filename ends in .sh


### PR DESCRIPTION
pre-commit 2.10 introduces stricter checks for hooks that don't use an environment - see https://github.com/pre-commit/pre-commit/pull/1771