### PR TITLE
Fix shellcheck hook by removing additional dependencies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,6 @@ repos:
         entry: pre_commit_hooks/shellcheck
         types: [shell]
         args: [-e, SC1091]
-        additional_dependencies: [shellcheck]
 
       - id: shfmt
         name: shfmt (local)

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -95,7 +95,6 @@
   language: script
   types: [shell]
   args: [-e, SC1091]
-  additional_dependencies: [shellcheck]
 
 - id: script-must-have-extension
   name: Non-executable shell script filename ends in .sh

--- a/pre_commit_hooks/shellcheck
+++ b/pre_commit_hooks/shellcheck
@@ -10,4 +10,9 @@ if [ "${DEBUG}" != unset ]; then
   set -x
 fi
 
+if ! command -v shellcheck >/dev/null 2>&1; then
+  echo 'This check needs shellcheck from https://github.com/koalaman/shellcheck'
+  exit 1
+fi
+
 shellcheck "$@"


### PR DESCRIPTION
The shellcheck hook breaks with the latest version of pre-commit (2.10.0) because of pre-commit/pre-commit#1771, which errors out when you use `language: script` and also specify additional dependencies.

From the pre-commit docs on `script`:
> This hook type will not be given a virtual environment to work with – if it needs additional dependencies the consumer must install them manually.

I've also added an error message if shellcheck isn't locally installed, to match what already exists for the shfmt hook (https://github.com/jumanjihouse/pre-commit-hooks/blob/master/pre_commit_hooks/shfmt#L13-L16)

[The CI failure is because of ruby + rubocop stuff and is unrelated to this PR - shellcheck passes]