### PR TITLE
Use Rubocop's flag to skip excluded files

### DIFF
--- a/pre_commit_hooks/run-rubocop
+++ b/pre_commit_hooks/run-rubocop
@@ -4,7 +4,7 @@ require 'English'
 # but pre-commit looks better if there is no output on success.
 args = ARGV.join(' ')
 puts args if ENV['DEBUG']
-output = `rubocop #{args} 2>&1`
+output = `rubocop --force-exclusion #{args} 2>&1`
 status = $CHILD_STATUS.exitstatus
 puts output if status != 0
 exit status


### PR DESCRIPTION
This flag been around since 2014 and version 0.20.0, and it avoids running rubocop against files that are excluded in the .rubocop.yml configuration.

- [1] https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md#new-features-102