### PR TITLE
git-check hook authorize to use pre-commit  exclude (#1)

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -92,9 +92,9 @@
   name: Test shell scripts with shellcheck
   description: Shell scripts conform to shellcheck
   entry: pre_commit_hooks/shellcheck
+  exclude_types: [zsh]
   language: script
   types: [shell]
-  args: [-e, SC1091]
 
 - id: script-must-have-extension
   name: Non-executable shell script filename ends in .sh
@@ -115,3 +115,4 @@
   language: script
   entry: pre_commit_hooks/shfmt
   types: [shell]
+  exclude_types: [zsh]

--- a/pre_commit_hooks/git-check
+++ b/pre_commit_hooks/git-check
@@ -6,4 +6,4 @@ readonly EMPTY_COMMIT
 
 # Report errors based on git configuration.
 # Respect overrides in .gitattributes if present.
-git diff-index --check "${EMPTY_COMMIT}"
+git diff-index --check "${EMPTY_COMMIT}" "$@"


### PR DESCRIPTION
Authorize git-check to use pre-commit exclude parameter.
And at the same time, it fixes also the issue that some errors can be displayed several times because pre-commit is calling the hook by batch of files