### PR TITLE
fix: check-mailmap has problems with log.showSignature true

### DIFF
--- a/pre_commit_hooks/check-mailmap
+++ b/pre_commit_hooks/check-mailmap
@@ -24,7 +24,7 @@ check_email() {
   #   How we want it to appear    How it appears in git commit
   #
   # See git-shortlog(1) for more details.
-  output="$(! git 2>&1 log --use-mailmap --pretty='%aN %aE' | tr '[:upper:]' '[:lower:]' | sort -u | awk '{print $NF}' | sort | uniq -c | sed -e 's/^[ \t]*//' | grep -v '^1[[:space:]]' | awk '{print $NF}')"
+  output="$(! git 2>&1 -c log.showSignature=false log --use-mailmap --pretty='%aN %aE' | tr '[:upper:]' '[:lower:]' | sort -u | awk '{print $NF}' | sort | uniq -c | sed -e 's/^[ \t]*//' | grep -v '^1[[:space:]]' | awk '{print $NF}')"
 
   if [ -n "${output}" ]; then
     RC=1
@@ -43,4 +43,4 @@ check_email() {
 }
 
 main
-exit ${RC}
+exit "${RC}"


### PR DESCRIPTION
Fixes #111

log.showSignature true shows additional signature information. This patch removes the detailed information.
